### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,30 +3,32 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: lemercie <lemercie@student.hive.fi>        +#+  +:+       +#+         #
+#    By: maheleni <maheleni@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/07/01 11:56:58 by lemercie          #+#    #+#              #
-#    Updated: 2025/03/05 10:45:34 by lemercie         ###   ########.fr        #
+#    Updated: 2025/03/05 14:19:18 by maheleni         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
+NAME	:= cub3D
 CC		:= cc
 CFLAGS	:= -Wextra -Wall -Werror
-NAME	:= cub3D
 LIBMLX	:= ./lib/MLX42
 LIBFT	:= ./lib/libft
 
 HEADERS	:= -I ./include -I $(LIBMLX)/include -I $(LIBFT)
 LIBS	:= $(LIBMLX)/build/libmlx42.a -ldl -lglfw -pthread -lm
 SRCDIR	:= ./src/
+OBJDIR	:= ./obj/
+
 SRCS	:= $(addprefix $(SRCDIR), main.c)
-OBJS	:= ${SRCS:.c=.o}
+OBJS	:= ${SRCS:$(SRCDIR)%.c=$(OBJDIR)%.o}
 
 all: libft libmlx $(NAME)
 
 # --depth 1 avoids downloading whole repo history
-.libmlx_cloned: 
-	git clone --depth 1 \
+.libmlx_cloned:
+	git clone --depth 1 --branch v2.4.1 --single-branch \
 		https://github.com/codam-coding-college/MLX42.git $(LIBMLX)
 	touch .libmlx_cloned
 
@@ -36,19 +38,23 @@ libmlx: .libmlx_cloned
 libft: 
 	make -C $(LIBFT)
 
-%.o: %.c
-	$(CC) $(CFLAGS) -o $@ -c $< $(HEADERS) 
-
 $(NAME): $(OBJS) ./include/cub3D.h
 	$(CC) $(OBJS) $(LIBS) $(LIBFT)/libft.a $(HEADERS) -o $(NAME)
 
+$(OBJDIR)%.o: $(SRCDIR)%.c
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CFLAGS) -o $@ -c $< $(HEADERS) 
+
 clean:
-	rm -rf $(OBJS)
+	#rm -rf $(OBJS)
+	rm -rf $(OBJDIR)
 	make clean -C $(LIBFT)
 	rm -fr $(LIBMLX)/build
 
 fclean: clean
 	rm -rf $(NAME)
+	rm -rf $(LIBMLX)		#maybe remove
+	rm -rf .libmlx_cloned	#maybe remove
 	make fclean -C $(LIBFT)
 
 re: clean all

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: maheleni <maheleni@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/07/01 11:56:58 by lemercie          #+#    #+#              #
-#    Updated: 2025/03/05 14:30:48 by maheleni         ###   ########.fr        #
+#    Updated: 2025/03/05 14:36:55 by maheleni         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -53,8 +53,8 @@ clean:
 
 fclean: clean
 	rm -rf $(NAME)
-	rm -rf $(LIBMLX)		#maybe remove
-	rm -rf .libmlx_cloned	#maybe remove
+	rm -rf $(LIBMLX)
+	rm -rf .libmlx_cloned
 	make fclean -C $(LIBFT)
 
 re: clean all

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: maheleni <maheleni@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/07/01 11:56:58 by lemercie          #+#    #+#              #
-#    Updated: 2025/03/05 14:36:55 by maheleni         ###   ########.fr        #
+#    Updated: 2025/03/05 14:39:36 by maheleni         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -46,7 +46,6 @@ $(OBJDIR)%.o: $(SRCDIR)%.c
 	$(CC) $(CFLAGS) -o $@ -c $< $(HEADERS) 
 
 clean:
-	#rm -rf $(OBJS)
 	rm -rf $(OBJDIR)
 	make clean -C $(LIBFT)
 	rm -fr $(LIBMLX)/build


### PR DESCRIPTION
Makefile now always clones one specific version of MLX42. All object files are created into ./obj dir. 

Issues:
#12 
#13 